### PR TITLE
Component auto-discovery config

### DIFF
--- a/components/AppCopyright.vue
+++ b/components/AppCopyright.vue
@@ -5,7 +5,9 @@
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'AppCopyright',
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/AppCopyright.vue
+++ b/components/AppCopyright.vue
@@ -5,10 +5,7 @@
 </template>
 
 <script>
-import VText from './lib/VText.vue'
-export default {
-  components: { VText },
-}
+export default {}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -60,13 +60,7 @@
 </template>
 
 <script>
-import VContainer from './lib/VContainer.vue'
-import VImage from './lib/VImage.vue'
-import VStack from './lib/VStack.vue'
-import VText from './lib/VText.vue'
-export default {
-  components: { VContainer, VImage, VStack, VText },
-}
+export default {}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -60,7 +60,9 @@
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'AppFooter',
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -7,11 +7,8 @@
 </template>
 
 <script>
-import VHeader from './lib/VHeader.vue'
-
 export default {
   name: 'AppHeader',
-  components: { VHeader },
   data() {
     return {
       headerCta: {},

--- a/components/AppSectionDescriptor.vue
+++ b/components/AppSectionDescriptor.vue
@@ -34,12 +34,8 @@
 </template>
 
 <script>
-import VHeading from './lib/VHeading.vue'
-import VStack from './lib/VStack.vue'
-import VText from './lib/VText.vue'
 export default {
   name: 'AppSectionDescriptor',
-  components: { VText, VStack, VHeading },
   props: {
     title: {
       type: String,

--- a/components/home/Community.vue
+++ b/components/home/Community.vue
@@ -104,6 +104,7 @@
 
 <script>
 export default {
+  name: 'Community',
   data() {
     return {
       providerType: 'Storage Provider',

--- a/components/home/Community.vue
+++ b/components/home/Community.vue
@@ -103,29 +103,7 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VButton from '../lib/VButton.vue'
-import VContainer from '../lib/VContainer.vue'
-import VDropdown from '../lib/VDropdown.vue'
-import VImage from '../lib/VImage.vue'
-import VInputGroup from '../lib/VInputGroup.vue'
-import VLabel from '../lib/VLabel.vue'
-import VRadioGroup from '../lib/VRadioGroup.vue'
-import VStack from '../lib/VStack.vue'
-import VTextField from '../lib/VTextField.vue'
 export default {
-  components: {
-    VContainer,
-    AppSectionDescriptor,
-    VStack,
-    VImage,
-    VButton,
-    VLabel,
-    VRadioGroup,
-    VInputGroup,
-    VTextField,
-    VDropdown,
-  },
   data() {
     return {
       providerType: 'Storage Provider',

--- a/components/home/Features.vue
+++ b/components/home/Features.vue
@@ -66,22 +66,7 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VBlurb from '../lib/VBlurb.vue'
-import VButton from '../lib/VButton.vue'
-import VContainer from '../lib/VContainer.vue'
-import VImage from '../lib/VImage.vue'
-import VStack from '../lib/VStack.vue'
-export default {
-  components: {
-    VContainer,
-    AppSectionDescriptor,
-    VStack,
-    VButton,
-    VImage,
-    VBlurb,
-  },
-}
+export default {}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/Features.vue
+++ b/components/home/Features.vue
@@ -66,7 +66,9 @@
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'Features',
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/HeroSection.vue
+++ b/components/home/HeroSection.vue
@@ -40,24 +40,8 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VButton from '../lib/VButton.vue'
-import VContainer from '../lib/VContainer.vue'
-import VHeading from '../lib/VHeading.vue'
-import VImage from '../lib/VImage.vue'
-import VStack from '../lib/VStack.vue'
-import VText from '../lib/VText.vue'
 export default {
   name: 'HeroSection',
-  components: {
-    VContainer,
-    VStack,
-    VImage,
-    VHeading,
-    VButton,
-    VText,
-    AppSectionDescriptor,
-  },
 }
 </script>
 

--- a/components/home/Interoperability.vue
+++ b/components/home/Interoperability.vue
@@ -33,7 +33,9 @@
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'Interoperability',
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/Interoperability.vue
+++ b/components/home/Interoperability.vue
@@ -33,14 +33,7 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VContainer from '../lib/VContainer.vue'
-import VImage from '../lib/VImage.vue'
-import VStack from '../lib/VStack.vue'
-import VText from '../lib/VText.vue'
-export default {
-  components: { VContainer, AppSectionDescriptor, VStack, VImage, VText },
-}
+export default {}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/Introduction.vue
+++ b/components/home/Introduction.vue
@@ -55,21 +55,7 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VContainer from '../lib/VContainer.vue'
-import VVideoThumbnail from '../lib/VVideoThumbnail.vue'
-import VImage from '../lib/VImage.vue'
-import VStack from '../lib/VStack.vue'
-
-export default {
-  components: {
-    VContainer,
-    AppSectionDescriptor,
-    VVideoThumbnail,
-    VImage,
-    VStack,
-  },
-}
+export default {}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/Introduction.vue
+++ b/components/home/Introduction.vue
@@ -55,7 +55,9 @@
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'Introduction',
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/NewsAndMedia.vue
+++ b/components/home/NewsAndMedia.vue
@@ -27,14 +27,7 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VButton from '../lib/VButton.vue'
-import VContainer from '../lib/VContainer.vue'
-import VImage from '../lib/VImage.vue'
-import VStack from '../lib/VStack.vue'
-export default {
-  components: { VContainer, AppSectionDescriptor, VStack, VButton, VImage },
-}
+export default {}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/NewsAndMedia.vue
+++ b/components/home/NewsAndMedia.vue
@@ -27,7 +27,9 @@
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'NewsAndMedia',
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/Newsletter.vue
+++ b/components/home/Newsletter.vue
@@ -32,23 +32,7 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VButton from '../lib/VButton.vue'
-import VContainer from '../lib/VContainer.vue'
-import VImage from '../lib/VImage.vue'
-import VInputGroup from '../lib/VInputGroup.vue'
-import VStack from '../lib/VStack.vue'
-import VTextField from '../lib/VTextField.vue'
 export default {
-  components: {
-    VContainer,
-    AppSectionDescriptor,
-    VStack,
-    VInputGroup,
-    VTextField,
-    VButton,
-    VImage,
-  },
   data() {
     return {
       newsletterEmail: '',

--- a/components/home/Newsletter.vue
+++ b/components/home/Newsletter.vue
@@ -33,6 +33,7 @@
 
 <script>
 export default {
+  name: 'Newsletter',
   data() {
     return {
       newsletterEmail: '',

--- a/components/home/OurPartners.vue
+++ b/components/home/OurPartners.vue
@@ -57,14 +57,7 @@
 </template>
 
 <script>
-import AppSectionDescriptor from '../AppSectionDescriptor.vue'
-import VButton from '../lib/VButton.vue'
-import VContainer from '../lib/VContainer.vue'
-import VImage from '../lib/VImage.vue'
-import VStack from '../lib/VStack.vue'
-export default {
-  components: { VContainer, AppSectionDescriptor, VStack, VButton, VImage },
-}
+export default {}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/home/OurPartners.vue
+++ b/components/home/OurPartners.vue
@@ -57,7 +57,9 @@
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'OurPartners',
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/components/lib/VAccordion.vue
+++ b/components/lib/VAccordion.vue
@@ -31,11 +31,8 @@
 </template>
 
 <script>
-import VText from './VText.vue'
-import VStack from './VStack.vue'
 export default {
   name: 'VAccordion',
-  components: { VText, VStack },
   props: {
     items: {
       type: Array,

--- a/components/lib/VBlurb.vue
+++ b/components/lib/VBlurb.vue
@@ -17,13 +17,8 @@
 </template>
 
 <script>
-import VHeading from './VHeading.vue'
-import VImage from './VImage.vue'
-import VStack from './VStack.vue'
-import VText from './VText.vue'
 export default {
   name: 'VBlurb',
-  components: { VStack, VImage, VHeading, VText },
   props: {
     image: {
       type: String,

--- a/components/lib/VDropdown.vue
+++ b/components/lib/VDropdown.vue
@@ -35,10 +35,8 @@
 </template>
 
 <script>
-import VImage from './VImage.vue'
 export default {
   name: 'VDropdown',
-  components: { VImage },
   props: {
     options: {
       type: Array,

--- a/components/lib/VHeader.vue
+++ b/components/lib/VHeader.vue
@@ -45,14 +45,8 @@
 </template>
 
 <script>
-import VButton from './VButton.vue'
-import VContainer from './VContainer.vue'
-import VImage from './VImage.vue'
-import VStack from './VStack.vue'
-import VText from './VText.vue'
 export default {
   name: 'VHeader',
-  components: { VContainer, VStack, VButton, VImage, VText },
   props: {
     logo: {
       type: String,

--- a/components/lib/VRadioGroup.vue
+++ b/components/lib/VRadioGroup.vue
@@ -24,11 +24,8 @@
 </template>
 
 <script>
-import VStack from './VStack.vue'
-import VLabel from './VLabel.vue'
 export default {
   name: 'VRadioGroup',
-  components: { VStack, VLabel },
   props: {
     layout: {
       type: String,
@@ -59,7 +56,7 @@ export default {
 }
 </script>
 
-<style  scoped>
+<style scoped>
 .radio-padding {
   padding: 1rem;
 }

--- a/components/lib/VText.stories.js
+++ b/components/lib/VText.stories.js
@@ -1,22 +1,16 @@
-import VStack from '~/components/lib/VStack'
-import VText from '~/components/lib/VText'
-
-export const colors = () => ({
-  components: { VStack, VText },
-  template: `
-    <v-stack direction="column" gap="2rem">
-      <v-text color="primary">
-        The quick brown fox jumps over the lazy dog.
-      </v-text>
-      <v-text color="secondary">
-        The quick brown fox jumps over the lazy dog.
-      </v-text>
-      <v-text color="link">
-        The quick brown fox jumps over the lazy dog.
-      </v-text>
-    </v-stack>
-  `,
-})
+export const colors = () => `
+  <v-stack direction="column" gap="2rem">
+    <v-text color="primary">
+      The quick brown fox jumps over the lazy dog.
+    </v-text>
+    <v-text color="secondary">
+      The quick brown fox jumps over the lazy dog.
+    </v-text>
+    <v-text color="link">
+      The quick brown fox jumps over the lazy dog.
+    </v-text>
+  </v-stack>
+`
 
 export default {
   title: 'VText',

--- a/components/lib/VVideoThumbnail.vue
+++ b/components/lib/VVideoThumbnail.vue
@@ -15,10 +15,8 @@
 </template>
 
 <script>
-import VImage from './VImage.vue'
 export default {
   name: 'VVideoThumbnail',
-  components: { VImage },
   props: {
     src: {
       type: String,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -19,7 +19,7 @@ export default {
 
   plugins: [],
 
-  components: true,
+  components: ['~/components', '~/components/home', '~/components/lib'],
 
   buildModules: [
     '@nuxtjs/eslint-module',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,37 +18,7 @@
 </template>
 
 <script>
-import AppHeader from '~/components/AppHeader.vue'
-import HeroSection from '~/components/home/HeroSection.vue'
-import Introduction from '~/components/home/Introduction.vue'
-import Features from '~/components/home/Features.vue'
-import Testimonials from '~/components/home/Testimonials.vue'
-import Investors from '~/components/home/Investors.vue'
-import Roadmap from '~/components/home/Roadmap.vue'
-import NewsAndMedia from '~/components/home/NewsAndMedia.vue'
-import OurPartners from '~/components/home/OurPartners.vue'
-import Interoperability from '~/components/home/Interoperability.vue'
-import Community from '~/components/home/Community.vue'
-import Newsletter from '~/components/home/Newsletter.vue'
-import AppFooter from '~/components/AppFooter.vue'
-import AppCopyright from '~/components/AppCopyright.vue'
 export default {
-  components: {
-    AppHeader,
-    HeroSection,
-    Introduction,
-    Features,
-    Testimonials,
-    Investors,
-    Roadmap,
-    NewsAndMedia,
-    OurPartners,
-    Interoperability,
-    Community,
-    Newsletter,
-    AppFooter,
-    AppCopyright,
-  },
   layout: 'page',
 }
 </script>


### PR DESCRIPTION
Adds directories to the `component` config to enable auto-discovery. This should allow us to remove all manual component imports and the `component` property from component options.

Adds a name property to components wherever it's missing.