### PR TITLE
Add a redirect rule for the blog

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,8 +9,13 @@
   NODE_ENV = "development"
 
 [[redirects]]
+  from = "/blog"
+  to = "https://blog.arcana.network"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/testnet"
   to = "https://testnet.arcana.network"
   status = 301
   force = true
-

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,9 +9,9 @@
   NODE_ENV = "development"
 
 [[redirects]]
-  from = "/blog"
-  to = "https://blog.arcana.network"
-  status = 301
+  from = "/blog/*"
+  to = "https://blog.arcana.network/:splat"
+  status = 200
   force = true
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 
 [[redirects]]
   from = "/blog/*"
-  to = "https://blog.arcana.network/:splat"
+  to = "http://3.111.24.6/:splat"
   status = 200
   force = true
 


### PR DESCRIPTION
**Changes:**

Adds a redirect rule to go from `/blog` to `blog.arcana.network`.

Resolve [AR-1125](https://team-1624093970686.atlassian.net/browse/AR-1125).

cc: @lakshmikanthfang 