### PR TITLE
[AR-1517] nav-bar is disjointed on mobile

### DIFF
--- a/components/lib/VHeader.vue
+++ b/components/lib/VHeader.vue
@@ -184,7 +184,7 @@ header {
     text-align: center;
   }
   .header-menu.show {
-    max-height: 100%;
+    max-height: 100vh;
     padding: 1rem;
   }
   .menu-icon {

--- a/components/lib/VHeader.vue
+++ b/components/lib/VHeader.vue
@@ -162,7 +162,7 @@ header {
 
 @media (--viewport-medium) {
   .header-menu {
-    position: fixed;
+    position: absolute;
     max-height: 0;
     top: 10rem;
     left: 0;

--- a/components/lib/VHeader.vue
+++ b/components/lib/VHeader.vue
@@ -164,7 +164,7 @@ header {
   .header-menu {
     position: fixed;
     max-height: 0;
-    top: 4.8rem;
+    top: 10rem;
     left: 0;
     right: 0;
     flex-direction: column;

--- a/components/lib/VHeader.vue
+++ b/components/lib/VHeader.vue
@@ -165,7 +165,7 @@ header {
   .header-menu {
     position: absolute;
     max-height: 0;
-    top: 10rem;
+    top: 100%;
     left: 0;
     right: 0;
     flex-direction: column;

--- a/components/lib/VHeader.vue
+++ b/components/lib/VHeader.vue
@@ -124,6 +124,7 @@ export default {
 header {
   padding: 1.5rem 0;
   z-index: 10000;
+  position: relative;
 }
 
 .header-menu-item {


### PR DESCRIPTION
# Resolves

- [AR-1517](https://team-1624093970686.atlassian.net/browse/AR-1517)

## Changes

1. Increased position-top prop in css.
2. Set position to `absolute`

## Screenshots
### Cross button issue
#### Before
<img width="332" alt="Screenshot 2022-02-10 at 5 15 20 PM" src="https://user-images.githubusercontent.com/40512676/153402576-5004e819-28b7-435f-8e60-b10dbdee7bd9.png">

#### After
<img width="332" alt="Screenshot 2022-02-10 at 5 15 26 PM" src="https://user-images.githubusercontent.com/40512676/153402634-d9145715-3656-4303-8b20-05f1c1be6314.png">

### Nav menu Scroll issue

#### Before
![website_navbar_before](https://user-images.githubusercontent.com/40512676/153404670-7487aee3-abc1-406d-a005-182d2f8b553c.gif)


#### After
![website_navbar_after](https://user-images.githubusercontent.com/40512676/153404688-db9097b5-9b55-44fb-b685-dccec56552de.gif)

# Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
