### PR TITLE
Remove open role for technical docs writer

### DIFF
--- a/components/careers/OpenPositions.vue
+++ b/components/careers/OpenPositions.vue
@@ -222,17 +222,6 @@ export default {
             compensation: '$40k – $100k | No equity',
             link: 'https://angel.co/company/arcana-network/jobs/1822884-lead-developer-evangelist',
           },
-          {
-            title: 'Technical Docs Writer',
-            requirements: [
-              'Be fully responsible for the quality, discoverability and accuracy of our docs',
-              'Document new products, features, and APIs',
-              'Document standards, guidelines, and best practices on documentation for developers',
-            ],
-            location: 'India | Remote',
-            compensation: '₹10L – ₹20L | No equity',
-            link: 'https://angel.co/company/arcana-network/jobs/1837985-technical-docs-writer',
-          },
         ],
         Sales: [
           {


### PR DESCRIPTION
# Resolves

- [AR-1619](https://team-1624093970686.atlassian.net/browse/AR-1619)

## Changes

- Removes open role for technical docs writer in Careers > Open Positions > Marketing

# Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
