### PR TITLE
Change active links to blue color

### DIFF
--- a/components/lib/VHeader.vue
+++ b/components/lib/VHeader.vue
@@ -134,11 +134,8 @@ header {
   transform: scale(0.98);
 }
 
-.active-link {
-  text-decoration: underline;
-  text-decoration-color: var(--color-white);
-  text-decoration-thickness: 0.125rem;
-  text-underline-offset: 0.25rem;
+.active-link > span {
+  color: var(--color-blue);
 }
 
 @media (--viewport-large) {


### PR DESCRIPTION
# Resolves

- [AR-3421](https://team-1624093970686.atlassian.net/browse/AR-3421)

## Changes

- Remove current styling for active header link and change active link color to blue

# Screenshots
Before
![Screenshot from 2022-07-26 07-47-42](https://user-images.githubusercontent.com/24249988/180908323-80232b44-bfed-452c-853e-eb29007448cd.png)

After
![Screenshot from 2022-07-26 07-47-50](https://user-images.githubusercontent.com/24249988/180908339-4493e6a6-f06a-455c-aa40-750a25484b46.png)

# Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
