### PR TITLE
Add tranform capitalize to tech header

### DIFF
--- a/components/tech/Technology.vue
+++ b/components/tech/Technology.vue
@@ -4,7 +4,7 @@
       <v-stack md-direction="column" justify="space-between" align="center">
         <v-stack direction="column" class="technology-hero-section">
           <app-section-descriptor title="Technology" />
-          <v-heading :level="1">
+          <v-heading :level="1" transform="capitalize">
             A comprehensive stack to help developers build secure and privacy
             preserving apps
           </v-heading>

--- a/components/tech/Technology.vue
+++ b/components/tech/Technology.vue
@@ -4,9 +4,9 @@
       <v-stack md-direction="column" justify="space-between" align="center">
         <v-stack direction="column" class="technology-hero-section">
           <app-section-descriptor title="Technology" />
-          <v-heading :level="1" transform="capitalize">
-            A comprehensive stack to help developers build secure and privacy
-            preserving apps
+          <v-heading :level="1">
+            A Comprehensive Stack To Help Developers Build Secure and Privacy
+            Preserving Apps
           </v-heading>
           <app-section-descriptor
             description="Decentralised storage, identity, access management, and KMS to help developers build secure and privacy‑preserving apps."


### PR DESCRIPTION
# Resolves

- [AR-3423](https://team-1624093970686.atlassian.net/browse/AR-3423)

## Changes

- Capitalcase Tech page hero header

# Screenshots
Before
![Screenshot from 2022-07-26 07-50-22](https://user-images.githubusercontent.com/24249988/180908663-f7162aa4-92d8-4f0c-b313-c3009d8c7e5f.png)

After
![Screenshot from 2022-07-26 07-50-34](https://user-images.githubusercontent.com/24249988/180908685-722d3d0d-3424-449d-8ccd-b038c40bad13.png)

# Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
