### PR TITLE
Add gradients behind illustration

### DIFF
--- a/components/about/OurPrinciples.vue
+++ b/components/about/OurPrinciples.vue
@@ -43,22 +43,19 @@ section {
 .illustration-container::before {
   content: '';
   position: absolute;
-  inset: -30%;
+  inset: -20%;
   z-index: -1;
   background: radial-gradient(
     50% 40% at 50% 40%,
     rgba(248, 81, 142, 0.2) 0%,
     rgba(0, 0, 0, 0) 100%
   );
-  filter: blur(40px);
 }
 
 .principles-illustration {
-  position: relative;
   width: 100%;
   max-width: 28rem;
   align-self: center;
-  z-index: 1;
 
   @media (--viewport-medium) {
     max-width: 20rem;

--- a/components/about/OurPrinciples.vue
+++ b/components/about/OurPrinciples.vue
@@ -10,10 +10,12 @@
             description="It is our mission to make it easy for developers to ensure the security and privacy of user data."
           />
         </v-stack>
-        <v-image
-          class="principles-illustration"
-          path="images/about-us-illustration.png"
-        />
+        <div class="illustration-container">
+          <v-image
+            class="principles-illustration"
+            path="images/about-us-illustration.png"
+          />
+        </div>
       </v-stack>
     </v-container>
   </section>
@@ -34,10 +36,29 @@ section {
   }
 }
 
+.illustration-container {
+  position: relative;
+}
+
+.illustration-container::before {
+  content: '';
+  position: absolute;
+  inset: -30%;
+  z-index: -1;
+  background: radial-gradient(
+    50% 40% at 50% 40%,
+    rgba(248, 81, 142, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  filter: blur(40px);
+}
+
 .principles-illustration {
+  position: relative;
   width: 100%;
   max-width: 28rem;
   align-self: center;
+  z-index: 1;
 
   @media (--viewport-medium) {
     max-width: 20rem;

--- a/components/home/Community.vue
+++ b/components/home/Community.vue
@@ -21,7 +21,9 @@
         md-align="start"
         style="margin-top: 1rem"
       >
-        <v-image path="images/build-illustration.svg" class="illustration" />
+        <div class="illustration-container">
+          <v-image path="images/build-illustration.svg" class="illustration" />
+        </div>
         <v-stack direction="column" align="start" style="max-width: 34rem">
           <app-section-descriptor
             heading="Build"
@@ -46,10 +48,12 @@
             heading="Provide"
             description="If have resources such as computing power or storage, you could generate revenue using unused resources. We need storage providers, distributed key generators and network validators and if you're interested, sign up below. "
           />
-          <v-image
-            path="images/provide-illustration.png"
-            class="illustration laptop-remove"
-          />
+          <div class="illustration-container">
+            <v-image
+              path="images/provide-illustration.png"
+              class="illustration laptop-remove"
+            />
+          </div>
           <v-label
             value="how do you want to participate:"
             strong
@@ -115,10 +119,12 @@
             {{ message }}
           </v-text>
         </v-stack>
-        <v-image
-          path="images/provide-illustration.png"
-          class="illustration tablet-remove mobile-remove"
-        />
+        <div class="illustration-container">
+          <v-image
+            path="images/provide-illustration.png"
+            class="illustration tablet-remove mobile-remove"
+          />
+        </div>
       </v-stack>
     </v-container>
   </section>
@@ -215,5 +221,32 @@ section {
 
 .subscription-message.success {
   color: var(--color-white);
+}
+
+.illustration-container {
+  position: relative;
+}
+
+.illustration-container::before {
+  content: '';
+  position: absolute;
+  inset: -20% -10%;
+  z-index: -1;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(180, 247, 252, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  filter: blur(40px);
+}
+
+.illustration-container:first-child::before {
+  inset: -40%;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(248, 81, 142, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  filter: none;
 }
 </style>

--- a/components/tech/JoinUs.vue
+++ b/components/tech/JoinUs.vue
@@ -74,8 +74,6 @@ export default {
 .joinus-illustration {
   width: 90%;
   max-width: 60rem;
-  position: relative;
-  z-index: 1;
 
   @media (--viewport-medium) {
     width: 150%;

--- a/components/tech/JoinUs.vue
+++ b/components/tech/JoinUs.vue
@@ -17,10 +17,12 @@ If you are interested in what we are building, checkout our existing openings, i
             :action="openCareers"
           />
         </v-stack>
-        <v-image
-          path="images/join-us-illustration.png"
-          class="joinus-illustration"
-        />
+        <div class="illustration-container">
+          <v-image
+            path="images/join-us-illustration.png"
+            class="joinus-illustration"
+          />
+        </div>
       </v-stack>
     </v-container>
   </section>
@@ -44,17 +46,39 @@ export default {
   max-width: 36rem;
 }
 
-.joinus-illustration {
-  width: 90%;
-  max-width: 60rem;
+.illustration-container {
+  position: relative;
 
   @media (--viewport-large) {
     margin-right: -20%;
   }
 
   @media (--viewport-medium) {
-    width: 150%;
     margin-top: -10%;
+  }
+}
+
+.illustration-container::before {
+  position: absolute;
+  inset: 0%;
+  content: '';
+  background: radial-gradient(
+    50% 50% at 40% 45%,
+    rgba(180, 247, 252, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  filter: blur(40px);
+  z-index: -1;
+}
+
+.joinus-illustration {
+  width: 90%;
+  max-width: 60rem;
+  position: relative;
+  z-index: 1;
+
+  @media (--viewport-medium) {
+    width: 150%;
   }
 }
 

--- a/components/tech/RoadmapList.vue
+++ b/components/tech/RoadmapList.vue
@@ -1,9 +1,11 @@
 <template>
   <section>
-    <v-image
-      path="images/roadmap-illustration.png"
-      class="roadmap-illustration"
-    />
+    <div class="illustration-container">
+      <v-image
+        path="images/roadmap-illustration.png"
+        class="roadmap-illustration"
+      />
+    </div>
     <v-container>
       <v-stack direction="column">
         <app-section-descriptor title="Roadmap" heading="Eyes on the Road" />
@@ -266,5 +268,22 @@ ul li {
 .selected-year > * {
   color: black;
   font-weight: 600;
+}
+
+.illustration-container {
+  position: relative;
+  z-index: -1;
+}
+
+.illustration-container::before {
+  content: '';
+  position: absolute;
+  inset: -50% 0% -100% -50%;
+  z-index: -1;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(248, 81, 142, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 </style>

--- a/components/tech/Technology.vue
+++ b/components/tech/Technology.vue
@@ -214,7 +214,7 @@ section {
 
 img {
   width: 90%;
-  max-width: 16rem;
+  max-width: 32rem;
 
   @media (--viewport-small) {
     max-width: 12rem;
@@ -287,7 +287,7 @@ img {
 }
 
 .hero-image {
-  max-width: 30rem;
+  min-width: 28rem;
   margin-top: 3rem;
 }
 

--- a/components/tech/Technology.vue
+++ b/components/tech/Technology.vue
@@ -12,24 +12,30 @@
             class="technology-hero-description"
           />
         </v-stack>
-        <v-image path="images/tech-illustration.png" class="hero-image" />
+        <div class="illustration-container hero-image-container">
+          <v-image path="images/tech-illustration.png" class="hero-image" />
+        </div>
       </v-stack>
 
       <v-stack justify="space-between" align="center">
-        <v-image
-          path="images/decentralised-storage.svg"
-          class="tablet-remove mobile-remove"
-        />
+        <div class="illustration-container tech-illustration storage">
+          <v-image
+            path="images/decentralised-storage.svg"
+            class="tablet-remove mobile-remove"
+          />
+        </div>
         <v-stack direction="column" md-align="center" class="tech-stack">
           <app-section-descriptor
             heading="Decentralised Storage"
             description="Storage nodes store only a piece of an encrypted file, ensuring data security at rest. No snooping by anyone!"
             class="tech-stack-description"
           />
-          <v-image
-            path="images/decentralised-storage.svg"
-            class="laptop-remove"
-          />
+          <div class="illustration-container tech-illustration storage">
+            <v-image
+              path="images/decentralised-storage.svg"
+              class="laptop-remove"
+            />
+          </div>
           <v-stack
             wrap
             class="features-list"
@@ -62,7 +68,9 @@
             description="No one except intended recipients can access files."
             class="tech-stack-description"
           />
-          <v-image path="images/e2e-encryption.svg" class="laptop-remove" />
+          <div class="illustration-container tech-illustration encryption">
+            <v-image path="images/e2e-encryption.svg" class="laptop-remove" />
+          </div>
           <v-stack
             wrap
             class="features-list"
@@ -88,24 +96,30 @@
             </v-chip>
           </v-stack>
         </v-stack>
-        <v-image
-          path="images/e2e-encryption.svg"
-          class="tablet-remove mobile-remove"
-        />
+        <div class="illustration-container tech-illustration encryption">
+          <v-image
+            path="images/e2e-encryption.svg"
+            class="tablet-remove mobile-remove"
+          />
+        </div>
       </v-stack>
 
       <v-stack justify="space-between" align="center">
-        <v-image
-          path="images/key-management.svg"
-          class="tablet-remove mobile-remove"
-        />
+        <div class="illustration-container tech-illustration key-management">
+          <v-image
+            path="images/key-management.svg"
+            class="tablet-remove mobile-remove"
+          />
+        </div>
         <v-stack direction="column" md-align="center" class="tech-stack">
           <app-section-descriptor
             heading="Non-Custodial Key Management"
             description="Users need not store or manage keys."
             class="tech-stack-description"
           />
-          <v-image path="images/key-management.svg" class="laptop-remove" />
+          <div class="illustration-container tech-illustration key-management">
+            <v-image path="images/key-management.svg" class="laptop-remove" />
+          </div>
           <v-stack
             wrap
             class="features-list"
@@ -140,7 +154,12 @@
             description="Your users truly own and control sharing access to their data."
             class="tech-stack-description"
           />
-          <v-image path="images/decentralised-iam.svg" class="laptop-remove" />
+          <div class="illustration-container tech-illustration iam">
+            <v-image
+              path="images/decentralised-iam.svg"
+              class="laptop-remove"
+            />
+          </div>
           <v-stack
             wrap
             md-direction="column"
@@ -167,10 +186,12 @@
             </v-chip>
           </v-stack>
         </v-stack>
-        <v-image
-          path="images/decentralised-iam.svg"
-          class="tablet-remove mobile-remove"
-        />
+        <div class="illustration-container tech-illustration iam">
+          <v-image
+            path="images/decentralised-iam.svg"
+            class="tablet-remove mobile-remove"
+          />
+        </div>
       </v-stack>
     </v-container>
   </section>
@@ -198,6 +219,63 @@ img {
   @media (--viewport-small) {
     max-width: 12rem;
   }
+}
+
+.illustration-container {
+  position: relative;
+}
+
+.hero-image-container::before {
+  content: '';
+  position: absolute;
+  inset: -20% -50% -50%;
+  z-index: -1;
+  background: radial-gradient(
+    50% 40% at 50% 55%,
+    rgba(248, 81, 142, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.tech-illustration::before {
+  content: '';
+  position: absolute;
+  inset: -50%;
+  z-index: -1;
+}
+
+.tech-illustration.storage::before {
+  z-index: 1;
+  background: radial-gradient(
+    50% 50% at 50%,
+    rgba(33, 130, 118, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.tech-illustration.encryption::before {
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(255, 233, 206, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  filter: blur(40px);
+}
+
+.tech-illustration.key-management::before {
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(248, 81, 142, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.tech-illustration.iam::before {
+  background: radial-gradient(
+    50% 50% at 50%,
+    rgba(33, 130, 118, 0.2) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 
 .technology-hero-section {

--- a/components/tech/Technology.vue
+++ b/components/tech/Technology.vue
@@ -212,15 +212,6 @@ section {
   }
 }
 
-img {
-  width: 90%;
-  max-width: 32rem;
-
-  @media (--viewport-small) {
-    max-width: 12rem;
-  }
-}
-
 .illustration-container {
   position: relative;
 }
@@ -289,6 +280,12 @@ img {
 .hero-image {
   min-width: 28rem;
   margin-top: 3rem;
+  max-width: 32rem;
+
+  @media (--viewport-small) {
+    min-width: auto;
+    max-width: 12rem;
+  }
 }
 
 .tech-stack {


### PR DESCRIPTION
# Resolves

- [AR-3425](https://team-1624093970686.atlassian.net/browse/AR-3425)

## Changes

- Add containers (div) to every illustration
- Relative position that container and then create a ::before pseudo element
- Absolute position that pseudo element and set top, right, bottom, left and background for that pseudo-element

# Screenshots
Before

![Screenshot from 2022-07-28 08-49-39](https://user-images.githubusercontent.com/24249988/181413341-0675d7b3-220f-406a-a773-b38778e78b16.png)

After

![Screenshot from 2022-07-28 08-49-47](https://user-images.githubusercontent.com/24249988/181413389-5159b96f-80d2-4474-bf70-917901aa053a.png)

Before

![Screenshot from 2022-07-28 08-49-57](https://user-images.githubusercontent.com/24249988/181413347-243ce056-fbac-4a68-8c94-1ffc07bc340d.png)

After

![Screenshot from 2022-07-28 08-50-06](https://user-images.githubusercontent.com/24249988/181413394-9bd3cad3-e743-4611-900b-890f85a36541.png)

Before

![Screenshot from 2022-07-28 08-50-21](https://user-images.githubusercontent.com/24249988/181413350-55e03579-a968-4815-a849-4c4791c2ca1c.png)

After

![Screenshot from 2022-07-28 08-50-30](https://user-images.githubusercontent.com/24249988/181413395-b2317f0c-5145-4b9d-926b-ae3e4c077282.png)


# Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
