### PR TITLE
[Hotfix] Change Discord invite link

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -43,7 +43,7 @@
             </a>
             <a
               style="margin-left: 3rem"
-              href="https://discord.gg/w6ej4FtqYS"
+              href="https://discord.com/invite/XRscu42B8V"
               target="_blank"
             >
               <v-image


### PR DESCRIPTION
# Resolves

- [AR-3988](https://team-1624093970686.atlassian.net/browse/AR-3988)

## Changes

Change the Discord invite link.

# Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.